### PR TITLE
feat(seller-dashboard): add transaction table and bid state pie chart…

### DIFF
--- a/src/modules/bid/controller/bid.controller.ts
+++ b/src/modules/bid/controller/bid.controller.ts
@@ -76,6 +76,14 @@ export class BidController {
     return this.bidService.findBidsByUser(sellerId);
   }
 
+  
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles('seller')
+  @Get('state-count/:userId')
+  async getBidStateCount(@Param('userId') userId: string) {
+    return this.bidService.getBidStateCountForUser(userId);
+  }
+
   /**
    * Get a specific Bid by ID
    */

--- a/src/modules/bid/usecase/bid.service.ts
+++ b/src/modules/bid/usecase/bid.service.ts
@@ -233,6 +233,9 @@ export class BidService {
     return bids;
   }
 
+    async getBidStateCountForUser(userId: string) {
+    return this.bidRepository.countBidsByStateForUser(userId);
+  }
   /**
    * Deletes a Bid (soft delete)
    */

--- a/src/modules/transaction/controller/transaction.controller.ts
+++ b/src/modules/transaction/controller/transaction.controller.ts
@@ -57,6 +57,17 @@ export class TransactionController {
     return await this.transactionService.getAllTransactionsBySellerId(sellerId);
   }
 
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles('seller')
+  @Get('seller/:sellerId')
+  async getSellerTransactions(
+    @Param('sellerId') sellerId: string,
+  ): Promise<any[]> {
+    return this.transactionService.getTransactionsBySeller(sellerId);
+  }
+
+
   // ✅ Get transaction by database ID
   @Get(':id')
   @UseGuards(JwtAuthGuard)

--- a/src/modules/transaction/persistence/transaction.repository.ts
+++ b/src/modules/transaction/persistence/transaction.repository.ts
@@ -125,4 +125,26 @@ export class TransactionRepository {
 
     return `TR-${nextNumber.toString().padStart(3, '0')}`;
   }
+
+async generateTransactionHistoryOfSeller(sellerId: string): Promise<Transaction[]> {
+  return this.transactionRepository.find({
+    where: {
+      bid: {
+        createdBy: {
+          id: sellerId,
+        },
+      },
+    },
+    relations: [
+      'bid',
+      'bid.createdBy',
+      'bid.rfq',
+      'bid.rfq.createdBy',
+      'payment',
+    ],
+    order: {
+      date: 'DESC',
+    },
+  });
+}
 }

--- a/src/modules/transaction/usecase/transaction.service.ts
+++ b/src/modules/transaction/usecase/transaction.service.ts
@@ -152,4 +152,24 @@ export class TransactionService {
     this.bid = transaction.bid?.id ?? '';
     this.date = transaction.date;
   }
+
+  async getTransactionsBySeller(sellerId: string) {
+    const transactionsSellerHistory = await this.transactionRepository.generateTransactionHistoryOfSeller(
+      sellerId)
+
+    return transactionsSellerHistory.map((tx) => ({
+      transactionId: tx.transactionId,
+      date: tx.date,
+      price: tx.payment?.price || null,
+      paymentGateway: tx.payment?.paymentGateway || null,
+      rfq: {
+        projectName: tx.bid?.rfq?.projectName,
+        purchaseNumber: tx.bid?.rfq?.purchaseNumber,
+        category: tx.bid?.rfq?.category,
+      },
+      bidTotalPrice: tx.bid?.totalPrice,
+      buyerName: `${tx.bid?.rfq?.createdBy?.firstName} ${tx.bid?.rfq?.createdBy?.lastName}`,
+    }));
+  }
+
 }


### PR DESCRIPTION
… end points 
the two seller end points
1, to visualize bid states (awarded/rejected) using data from bid stats endpoint:
  { "state": "rejected", "count": 4 },
  { "state": "awarded", "count": 7 }
]
2, I Implemented table to display detailed transactions History
[transactionId, date, price, paymentGateway, projectName, purchaseNumber, category,bidTotalPrice and buyerName ]
