### PR TITLE
feat(buyer-dashboard): implement RFQ history table and state summary …

### DIFF
--- a/src/modules/rfq/controller/rfq.controller.ts
+++ b/src/modules/rfq/controller/rfq.controller.ts
@@ -147,4 +147,20 @@ export class RFQController {
   ): Promise<void> {
     return this.rfqService.downloadFile(rfqId, filename, res);
   }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles('buyer')
+  @Get('history/:buyerId')
+  async getRfqHistory(@Param('buyerId') buyerId: string) {
+    return this.rfqService.getRfqHistoryByBuyer(buyerId);
+  }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles('buyer')
+  @Get('dashboard/summary/:buyerId')
+  async getBuyerRfqSummary(@Param('buyerId') buyerId: string) {
+    return this.rfqService.getBuyerRfqSummary(buyerId);
+  }
+
+
 }

--- a/src/modules/rfq/persistence/rfq.repository.ts
+++ b/src/modules/rfq/persistence/rfq.repository.ts
@@ -84,6 +84,20 @@ export class RFQRepository {
     return rfq;
   }
 
+async getRfqHistoryByBuyer(buyerId: string): Promise<RFQ[]> {
+  return this.rfqRepository.find({
+    where: { createdBy: { id: buyerId } },
+    relations: [
+      'bids',
+      'bids.transactions',
+      'bids.transactions.payment',
+      'bids.createdBy',
+    ],
+    order: {
+      createdAt: 'DESC',
+    },
+  });
+}
   /**
    * Retrieves an RFQ by purchaseNumber
    */


### PR DESCRIPTION
…chart data
1, Fetches all RFQs for a buyer with related bid, transaction, and payment details for table display.
2, Aggregates RFQs by state (opened, closed, awarded) and returns data formatted for pie chart visualization on the dashboard.
